### PR TITLE
Improve performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.8.0] - 2022-08-29
+### Breaking
+
+- OsInfo.instance has been removed
+- OsInfo.init() has been replaced by OsInfo.get() which will return a future the instance
+- PreferencesStorage now takes a future to the platform preferences and all get methods now return a future instead of a value
+
 ## [0.7.2] - 2022-06-24
 ### Updated
 - Dependencies
@@ -31,6 +38,13 @@
 ### Added
 
 - Docs in the README.md
+
+## [0.7.0] - 2022-09-29
+### Breaking
+
+- OsInfo.instance has been removed
+- OsInfo.init() has been renamed to OsInfo.get() and will now return a future to the instance
+- Cleam
 
 ## [0.6.1] - 2021-12-14
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,13 +39,6 @@
 
 - Docs in the README.md
 
-## [0.7.0] - 2022-09-29
-### Breaking
-
-- OsInfo.instance has been removed
-- OsInfo.init() has been renamed to OsInfo.get() and will now return a future to the instance
-- Cleam
-
 ## [0.6.1] - 2021-12-14
 ### Added
 

--- a/lib/src/theming/base_theme.dart
+++ b/lib/src/theming/base_theme.dart
@@ -6,16 +6,15 @@ import 'package:icapps_architecture/src/util/environment/os_info.dart';
 @immutable
 class BaseThemeData {
   /// Gets the base theme to use to build new themes on
-  static ThemeData get baseTheme {
-    return ThemeData(
-      pageTransitionsTheme: PageTransitionsTheme(
-        builders: {
-          TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
-          TargetPlatform.android:
-              getCorrectPageTransitionBuilder(OsInfo.instance),
-        },
-      ),
-    );
+  static Future<ThemeData> get baseTheme {
+    return OsInfo.get().then((osInfo) => ThemeData(
+          pageTransitionsTheme: PageTransitionsTheme(
+            builders: {
+              TargetPlatform.iOS: const CupertinoPageTransitionsBuilder(),
+              TargetPlatform.android: getCorrectPageTransitionBuilder(osInfo),
+            },
+          ),
+        ));
   }
 
   /// Builds the correct page transition based on the current OS

--- a/lib/src/util/environment/os_info.dart
+++ b/lib/src/util/environment/os_info.dart
@@ -33,13 +33,11 @@ class OsInfo {
 
   /// Initializes the os info
   static Future<OsInfo> get() {
-    if (_instance == null) {
-      _instance ??= initOsConfig().then((config) => OsInfo(
-            config.androidSdk,
-            config.iosVersion,
-            config.isWeb,
-          ));
-    }
+    _instance ??= initOsConfig().then((config) => OsInfo(
+          config.androidSdk,
+          config.iosVersion,
+          config.isWeb,
+        ));
     return _instance!;
   }
 

--- a/lib/src/util/environment/os_info.dart
+++ b/lib/src/util/environment/os_info.dart
@@ -14,7 +14,7 @@ class OsInfo {
 
   /// Indicates that this is a non-native application
   final bool isWeb;
-  static OsInfo? _instance;
+  static Future<OsInfo>? _instance;
 
   /// Returns true if the app is running natively on android
   bool get isAndroid => androidSdk > 0;
@@ -32,18 +32,19 @@ class OsInfo {
   bool get isIOS13OrAbove => iosVersion >= 13;
 
   /// Initializes the os info
-  static Future<void> init() async {
+  static Future<OsInfo> get() {
     if (_instance == null) {
-      final config = await initOsConfig();
-      _instance ??= OsInfo(config.androidSdk, config.iosVersion, config.isWeb);
+      _instance ??= initOsConfig().then((config) => OsInfo(
+            config.androidSdk,
+            config.iosVersion,
+            config.isWeb,
+          ));
     }
+    return _instance!;
   }
 
   @visibleForTesting
   OsInfo(this.androidSdk, this.iosVersion, this.isWeb);
-
-  /// Returns the [OsInfo] instance. Call [init] first!
-  static OsInfo get instance => _instance!;
 }
 
 final bool isDeviceAndroid = platformIsAndroid;

--- a/lib/src/util/preferences/preferences_storage.dart
+++ b/lib/src/util/preferences/preferences_storage.dart
@@ -4,8 +4,8 @@ import 'package:shared_preferences/shared_preferences.dart';
 /// Utility class to facilitate storing shared preferences
 abstract class SharedPreferenceStorage implements SimpleKeyValueStorage {
   /// Create a new instance of SharedPreferenceStorage
-  factory SharedPreferenceStorage(SharedPreferences preferences) =>
-      _SharedPreferenceStorage(preferences);
+  factory SharedPreferenceStorage(Future<SharedPreferences> preferences) =
+      _SharedPreferenceStorage;
 
   /// Saves the given string [value] to the storage with [key]
   Future<void> saveString({required String key, required String value});
@@ -21,73 +21,77 @@ abstract class SharedPreferenceStorage implements SimpleKeyValueStorage {
 
   /// Retrieves the stored string value for [key].
   /// Returns null if the value is not found
-  String? getString(String key);
+  Future<String?> getString(String key);
 
   /// Retrieves the stored boolean value for [key].
   /// Returns null if the value is not found
-  bool? getBoolean(String key);
+  Future<bool?> getBoolean(String key);
 
   /// Retrieves the stored integer value for [key].
   /// Returns null if the value is not found
-  int? getInt(String key);
+  Future<int?> getInt(String key);
 
   /// Retrieves the stored double value for [key].
   /// Returns null if the value is not found
-  double? getDouble(String key);
+  Future<double?> getDouble(String key);
 
   /// Deletes the value stored for [key]
   Future<void> deleteKey(String key);
 
   /// Returns true if there is a value for [key]
-  bool containsKey(String key);
+  Future<bool> containsKey(String key);
 }
 
 class _SharedPreferenceStorage implements SharedPreferenceStorage {
-  final SharedPreferences _sharedPreferences;
+  final Future<SharedPreferences> _sharedPreferences;
 
   _SharedPreferenceStorage(this._sharedPreferences);
 
   @override
   Future<void> saveString({required String key, required String value}) =>
-      _sharedPreferences.setString(key, value);
+      _sharedPreferences.then((prefs) => prefs.setString(key, value));
 
   @override
   Future<void> saveBoolean({required String key, required bool value}) =>
-      _sharedPreferences.setBool(key, value);
+      _sharedPreferences.then((prefs) => prefs..setBool(key, value));
 
   @override
   Future<void> saveInt({required String key, required int value}) =>
-      _sharedPreferences.setInt(key, value);
+      _sharedPreferences.then((prefs) => prefs..setInt(key, value));
 
   @override
   Future<void> saveDouble({required String key, required double value}) =>
-      _sharedPreferences.setDouble(key, value);
+      _sharedPreferences.then((prefs) => prefs.setDouble(key, value));
 
   @override
-  String? getString(String key) => _sharedPreferences.getString(key);
+  Future<String?> getString(String key) =>
+      _sharedPreferences.then((prefs) => prefs.getString(key));
 
   @override
-  bool? getBoolean(String key) => _sharedPreferences.getBool(key);
+  Future<bool?> getBoolean(String key) =>
+      _sharedPreferences.then((prefs) => prefs.getBool(key));
 
   @override
-  int? getInt(String key) => _sharedPreferences.getInt(key);
+  Future<int?> getInt(String key) =>
+      _sharedPreferences.then((prefs) => prefs.getInt(key));
 
   @override
-  double? getDouble(String key) => _sharedPreferences.getDouble(key);
+  Future<double?> getDouble(String key) =>
+      _sharedPreferences.then((prefs) => prefs.getDouble(key));
 
   @override
-  Future<void> deleteKey(String key) => _sharedPreferences.remove(key);
+  Future<void> deleteKey(String key) =>
+      _sharedPreferences.then((prefs) => prefs.remove(key));
 
   @override
-  bool containsKey(String key) => _sharedPreferences.containsKey(key);
+  Future<bool> containsKey(String key) =>
+      _sharedPreferences.then((prefs) => prefs.containsKey(key));
 
   @override
-  Future<String?> getValue({required String key}) =>
-      Future.value(getString(key));
+  Future<String?> getValue({required String key}) => getString(key);
 
   @override
-  Future<bool> hasValue({required String key}) =>
-      Future.value(containsKey(key));
+  Future<bool> hasValue({required String key}) => containsKey(key);
 
   @override
   Future<void> removeValue({required String key}) => deleteKey(key);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ homepage: https://github.com/icapps/flutter-icapps-architecture
 repository: https://github.com/icapps/flutter-icapps-architecture
 issue_tracker: https://github.com/icapps/flutter-icapps-architecture/issues
 
-version: 0.7.2
+version: 0.8.0
 
 environment:
   sdk: '>=2.17.0 <3.0.0'
@@ -13,7 +13,7 @@ environment:
 dependencies:
   computer: ^3.2.1
   connectivity_plus: ^2.3.5
-  device_info_plus: ^4.0.0
+  device_info_plus: ^4.1.2
   dio: ^4.0.6
   flutter:
     sdk: flutter
@@ -28,7 +28,7 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.2.0
   connectivity_plus_platform_interface: ^1.2.1
-  device_info_plus_platform_interface: ^2.3.0+1
+  device_info_plus_platform_interface: ^3.0.0
   flutter_lints: ^2.0.1
 
 flutter:

--- a/test/theming/base_theme_test.dart
+++ b/test/theming/base_theme_test.dart
@@ -4,12 +4,12 @@ import 'package:icapps_architecture/icapps_architecture.dart';
 
 void main() {
   setUp(() async {
-    await OsInfo.init();
+    await OsInfo.get();
   });
 
   group('Base theme data test', () {
-    test('Test base theme page builders', () {
-      final theme = BaseThemeData.baseTheme;
+    test('Test base theme page builders', () async {
+      final theme = await BaseThemeData.baseTheme;
       expect(theme.pageTransitionsTheme.builders[TargetPlatform.android],
           isInstanceOf<ZoomPageTransitionsBuilder>());
       expect(theme.pageTransitionsTheme.builders[TargetPlatform.iOS],

--- a/test/util/environment/os_config_test.dart
+++ b/test/util/environment/os_config_test.dart
@@ -14,20 +14,20 @@ import 'os_config_test.mocks.dart';
 void main() {
   group('OS config tests', () {
     test('OS config from io, unknown', () async {
-      await OsInfo.init();
-      expect(OsInfo.instance.isWeb, false);
-      expect(OsInfo.instance.androidSdk, 0);
-      expect(OsInfo.instance.iosVersion, 0);
-      expect(OsInfo.instance.isAndroid, false);
-      expect(OsInfo.instance.isIOS, false);
+      final osInfo = await OsInfo.get();
+      expect(osInfo.isWeb, false);
+      expect(osInfo.androidSdk, 0);
+      expect(osInfo.iosVersion, 0);
+      expect(osInfo.isAndroid, false);
+      expect(osInfo.isIOS, false);
     });
     test('OS config is at least', () async {
-      await OsInfo.init();
-      expect(OsInfo.instance.isAtLeastAndroid10, false);
-      expect(OsInfo.instance.isAtLeastPie, false);
-      expect(OsInfo.instance.isIOS13OrAbove, false);
-      expect(OsInfo.instance.isAndroid, false);
-      expect(OsInfo.instance.isIOS, false);
+      final osInfo = await OsInfo.get();
+      expect(osInfo.isAtLeastAndroid10, false);
+      expect(osInfo.isAtLeastPie, false);
+      expect(osInfo.isIOS13OrAbove, false);
+      expect(osInfo.isAndroid, false);
+      expect(osInfo.isIOS, false);
     });
     test('OS config from stub', () async {
       final info = await stub.initOsConfig();
@@ -44,7 +44,6 @@ void main() {
             board: 'surf',
             supportedAbis: ['x256-powermaxx'],
             systemFeatures: ['fishingrod'],
-            androidId: '4 (chosen by dice roll)',
             display: 'iMAX',
             device: 'yes',
             model: 'hot',

--- a/test/util/logging/logging_test.dart
+++ b/test/util/logging/logging_test.dart
@@ -25,7 +25,7 @@ class TestPrefixHelper {
 }
 
 @GenerateMocks([], customMocks: [
-  MockSpec<Log>(returnNullOnMissingStub: true),
+  MockSpec<Log>(onMissingStub: OnMissingStub.returnDefault),
 ])
 void main() {
   group('Static logger', () {
@@ -181,7 +181,7 @@ void testWithLogger() {
       expect(
           messages[4].lines[4],
           matches(
-              '\\d+:\\d+:\\d+\\.\\d+\\s+#2   StackZoneSpecification._registerUnaryCallback.<anonymous closure> \\(package:stack_trace/src/stack_zone_specification.dart:125:47\\)'));
+              '\\d+:\\d+:\\d+\\.\\d+\\s+#2   StackZoneSpecification._registerUnaryCallback.<anonymous closure> \\(package:stack_trace/src/stack_zone_specification.dart:\\d+:\\d+\\)'));
       expect(messages[4].lines[5],
           matches('\\d+:\\d+:\\d+\\.\\d+\\s+#3   <asynchronous suspension>'));
       expect(messages[4].lines[0],

--- a/test/util/preferences/preferences_storage_test.dart
+++ b/test/util/preferences/preferences_storage_test.dart
@@ -1,11 +1,12 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:icapps_architecture/icapps_architecture.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
-import 'preferences_storage_test.mocks.dart';
 import '../../test_util.dart';
+import 'preferences_storage_test.mocks.dart';
 
 @GenerateMocks([SharedPreferences])
 void main() {
@@ -14,7 +15,7 @@ void main() {
 
   setUp(() {
     sharedPreferences = MockSharedPreferences();
-    sut = SharedPreferenceStorage(sharedPreferences);
+    sut = SharedPreferenceStorage(SynchronousFuture(sharedPreferences));
 
     when(sharedPreferences.setString(any, any))
         .thenAnswer((_) => Future.value(true));
@@ -70,9 +71,9 @@ void main() {
       verifyNoMoreInteractions(sharedPreferences);
     });
 
-    test('SharedPrefsStorage should read bool', () {
+    test('SharedPrefsStorage should read bool', () async {
       when(sharedPreferences.getBool('Key')).thenAnswer((_) => true);
-      final result = sut.getBoolean('Key');
+      final result = await sut.getBoolean('Key');
       expect(result, true);
       verify(sharedPreferences.getBool('Key')).calledOnce();
       verifyNoMoreInteractions(sharedPreferences);
@@ -86,9 +87,9 @@ void main() {
       verifyNoMoreInteractions(sharedPreferences);
     });
 
-    test('SharedPrefsStorage should read double', () {
+    test('SharedPrefsStorage should read double', () async {
       when(sharedPreferences.getDouble('Key')).thenAnswer((_) => 1.23435);
-      final result = sut.getDouble('Key');
+      final result = await sut.getDouble('Key');
       expect(result, 1.23435);
       verify(sharedPreferences.getDouble('Key')).calledOnce();
       verifyNoMoreInteractions(sharedPreferences);
@@ -102,9 +103,9 @@ void main() {
       verifyNoMoreInteractions(sharedPreferences);
     });
 
-    test('SharedPrefsStorage should read double', () {
+    test('SharedPrefsStorage should read double', () async {
       when(sharedPreferences.getInt('Key')).thenAnswer((_) => 21345);
-      final result = sut.getInt('Key');
+      final result = await sut.getInt('Key');
       expect(result, 21345);
       verify(sharedPreferences.getInt('Key')).calledOnce();
       verifyNoMoreInteractions(sharedPreferences);


### PR DESCRIPTION
- OsInfo.instance has been removed
- OsInfo.init() has been replaced by OsInfo.get() which will return a future the instance
- PreferencesStorage now takes a future to the platform preferences and all get methods now return a future instead of a value