### PR TITLE
Resolve #118 BaseThemeProviderWidget does not pass named super.key parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Added posiblity to add custom effects
 - Removed BetterInkwell widget
 
-# Changelog
 ## [2.1.5] - 2024-02-12
 ### Changed
 -  Fixed missing material in the TouchFeedback widget

--- a/lib/src/widget/provider/theme_provider_widget.dart
+++ b/lib/src/widget/provider/theme_provider_widget.dart
@@ -16,6 +16,7 @@ class BaseThemeProviderWidget<Theme, Localization> extends StatelessWidget {
     this.childBuilderTheme,
     this.childBuilderLocalization,
     this.childBuilder,
+    super.key,
   });
 
   @override

--- a/test/widget/provider/theme_provider_widget_test.dart
+++ b/test/widget/provider/theme_provider_widget_test.dart
@@ -10,16 +10,11 @@ class Locale {}
 
 class ThemeProviderWidget extends BaseThemeProviderWidget<Theme, Locale> {
   const ThemeProviderWidget({
-    Widget Function(BuildContext context, Theme theme)? childBuilderTheme,
-    Widget Function(BuildContext context, Locale localization)?
-        childBuilderLocalization,
-    Widget Function(BuildContext context, Theme theme, Locale localization)?
-        childBuilder,
-  }) : super(
-          childBuilderTheme: childBuilderTheme,
-          childBuilder: childBuilder,
-          childBuilderLocalization: childBuilderLocalization,
-        );
+    super.childBuilderTheme,
+    super.childBuilderLocalization,
+    super.childBuilder,
+    super.key,
+  });
 }
 
 LocaleT getLocale<LocaleT>(BuildContext _) => Locale() as LocaleT;


### PR DESCRIPTION
Resolving a ticket https://github.com/icapps/flutter-icapps-architecture/issues/118 and a small correction in the CHANGELOG